### PR TITLE
Update proposal and strategy flow

### DIFF
--- a/frontend/src/lib/components/AppHeader.svelte
+++ b/frontend/src/lib/components/AppHeader.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <header class=" bg-black py-4">
-  <div class="flex justify-between items-center max-w-screen-xl mx-auto">
+  <div class="flex justify-between px-14 ml-10 items-center">
     <a href="/app">
       <h1 class="text-white font-bold text-2xl">MATUSALEM...</h1>
     </a>

--- a/frontend/src/lib/components/AppSidebar.svelte
+++ b/frontend/src/lib/components/AppSidebar.svelte
@@ -25,17 +25,6 @@
     <Button
       color="white"
       class="mb-6 nav-link"
-      href="/app/proposals"
-    >
-      <Proposal
-        slot="leftIcon"
-        class="fill-black"
-      />
-      Proposals
-    </Button>
-    <Button
-      color="white"
-      class="mb-6 nav-link"
       href="/app/strategies"
     >
       <Mind
@@ -43,6 +32,17 @@
         class="fill-black"
       />
       Strategies
+    </Button>
+    <Button
+      color="white"
+      class="mb-6 nav-link"
+      href="/app/proposals"
+    >
+      <Proposal
+        slot="leftIcon"
+        class="fill-black"
+      />
+      Proposals
     </Button>
     <Button
       color="white"

--- a/frontend/src/lib/components/MetaMaskConnect.svelte
+++ b/frontend/src/lib/components/MetaMaskConnect.svelte
@@ -42,7 +42,7 @@
     class="w-10 h-10"
     slot="leftIcon"
   />
-  <span class="text-14"
-    >{userAddress ? truncateAddress(userAddress) : "Connect to vote"}</span
-  >
+  <span class="text-14">
+    {userAddress ? truncateAddress(userAddress) : "Connect"}
+  </span>
 </button>

--- a/frontend/src/lib/components/StrategyForm.svelte
+++ b/frontend/src/lib/components/StrategyForm.svelte
@@ -8,6 +8,7 @@
   import { contracts } from "$lib/svark";
   import { strategyTuple } from "$lib/utils/strategyTuple";
   import strats from "$lib/stores/strats";
+  import { genId } from "$lib/utils/genId";
 
   export let assets: typeof bestOptions;
 
@@ -40,10 +41,6 @@
     assetData = data;
   });
 
-  function genId() {
-    return Number($strats[$strats.length - 1]?.id || 0) + 1;
-  }
-
   async function handleSubmit() {
     const strategy = strategyTuple(assets);
 
@@ -56,7 +53,7 @@
     strats.update((st) => [
       ...st,
       {
-        id: genId().toString(),
+        id: genId($strats, "id").toString(),
         submittedBy: stratData.from,
         data: strategy,
       },

--- a/frontend/src/lib/components/StrategyForm.svelte
+++ b/frontend/src/lib/components/StrategyForm.svelte
@@ -36,7 +36,7 @@
   });
 
   async function handleSubmit() {
-    strats.createStrategy(assets);
+    await strats.createStrategy(assets);
     goto("/app/strategies");
   }
 </script>

--- a/frontend/src/lib/components/StrategyForm.svelte
+++ b/frontend/src/lib/components/StrategyForm.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { BigNumber } from "ethers";
   import { goto } from "$app/navigation";
   import Button from "$lib/components/Button.svelte";
   import type { bestOptions } from "$lib/data/assetStrategy";
   import StratPieChart from "./StratPieChart.svelte";
-  import { contracts } from "$lib/svark";
-  import { strategyTuple } from "$lib/utils/strategyTuple";
   import strats from "$lib/stores/strats";
-  import { genId } from "$lib/utils/genId";
 
   export let assets: typeof bestOptions;
 
@@ -16,8 +12,6 @@
   $: valid = total === 100;
 
   let assetData: any[] = [];
-
-  $: treasuryContract = $contracts.treasury;
 
   onMount(async () => {
     const data = await Promise.all(
@@ -42,23 +36,7 @@
   });
 
   async function handleSubmit() {
-    const strategy = strategyTuple(assets);
-
-    const tuple = strategy.map(BigNumber.from);
-
-    const stratData = await $treasuryContract.createStrategy(tuple);
-
-    console.log(stratData);
-
-    strats.update((st) => [
-      ...st,
-      {
-        id: genId($strats, "id").toString(),
-        submittedBy: stratData.from,
-        data: strategy,
-      },
-    ]);
-
+    strats.createStrategy(assets);
     goto("/app/strategies");
   }
 </script>

--- a/frontend/src/lib/stores/proposals.ts
+++ b/frontend/src/lib/stores/proposals.ts
@@ -22,7 +22,7 @@ export const initialState = [
     voteList: ["0", "0", "0", "0", "0", "0", "0", "0"],
   },
   {
-    proposalId: "3",
+    proposalId: "4",
     strategyId: "5",
     finished: "0",
     voteList: ["0", "0", "0", "0", "0", "0", "0", "0"],

--- a/frontend/src/lib/stores/strats.ts
+++ b/frontend/src/lib/stores/strats.ts
@@ -1,8 +1,10 @@
 import { get, writable } from "svelte/store";
+import type { Writable } from "svelte/store";
 import { BigNumber } from "ethers";
 import { contracts } from "$lib/svark";
 import { reduceStrategy } from "$lib/utils/strategyTuple";
 import { genId } from "$lib/utils/genId";
+import type { Contract } from "$lib/svark/contractsStore";
 
 export const initialState = [
   {
@@ -101,9 +103,11 @@ export type Strategy = {
 };
 
 function strategiesStore() {
-  const treasuryContract = get(contracts).treasury;
-
   const { subscribe, update } = writable<Strategy[]>(initialState);
+
+  let treasuryContract: Writable<Contract>;
+
+  contracts.subscribe((value) => (treasuryContract = value.treasury));
 
   async function createStrategy(
     assets: {

--- a/frontend/src/lib/stores/strats.ts
+++ b/frontend/src/lib/stores/strats.ts
@@ -44,6 +44,52 @@ export const initialState = [
     id: "8",
     submittedBy: "0xAf4f3BDe74e49dDF63Dee2a5Df05687e67553D3f",
     data: [68, 14, 18],
+    assets: [
+      {
+        name: "rocket pool",
+        val: 70,
+      },
+      {
+        name: "euler",
+        val: 12,
+      },
+      {
+        name: "uniswap",
+        val: 2,
+      },
+      {
+        name: "wrapped-bitcoin",
+        val: 2,
+      },
+      {
+        name: "maker",
+        val: 2,
+      },
+      {
+        name: "filecoin",
+        val: 2,
+      },
+      {
+        name: "aave",
+        val: 2,
+      },
+      {
+        name: "curve-dao-token",
+        val: 2,
+      },
+      {
+        name: "nexo",
+        val: 2,
+      },
+      {
+        name: "the-graph",
+        val: 2,
+      },
+      {
+        name: "sandclock",
+        val: 2,
+      },
+    ],
   },
 ];
 

--- a/frontend/src/lib/stores/strats.ts
+++ b/frontend/src/lib/stores/strats.ts
@@ -47,7 +47,12 @@ export const initialState = [
   },
 ];
 
-export type Strategy = typeof initialState[0];
+export type Strategy = {
+  id: string;
+  submittedBy: string;
+  data: number[];
+  assets?: { name: string; val: number }[];
+};
 
 function strategiesStore() {
   const treasuryContract = get(contracts).treasury;
@@ -74,6 +79,7 @@ function strategiesStore() {
         id: genId(strategies, "id").toString(),
         submittedBy: from,
         data: strategy,
+        assets,
       },
     ]);
   }

--- a/frontend/src/lib/svark/contractsStore.ts
+++ b/frontend/src/lib/svark/contractsStore.ts
@@ -7,18 +7,14 @@ import _baseStore from "./_baseStore";
 
 // Store of all contract stores. Subscribes to account changes
 
-type ContractsStoreType = Record<
-  string,
-  Writable<StarknetContract | EthersContract>
->;
+export type Contract = StarknetContract | EthersContract;
+
+type ContractsStoreType = Record<string, Writable<Contract>>;
 
 export const store = writable<ContractsStoreType>({});
 
 const contractsStore = _baseStore(store, ({ _set, subscribe }) => {
-  function addContract(
-    name: string,
-    contract: Writable<StarknetContract | EthersContract>
-  ) {
+  function addContract(name: string, contract: Writable<Contract>) {
     if (!get(store)[name]) {
       _set({
         [name]: contract,

--- a/frontend/src/lib/utils/genId.ts
+++ b/frontend/src/lib/utils/genId.ts
@@ -1,0 +1,3 @@
+export function genId(array: Record<string, any>[], idProp: string) {
+  return Number(array[array.length - 1]?.[idProp] || 0) + 1;
+}

--- a/frontend/src/lib/utils/strategyTuple.ts
+++ b/frontend/src/lib/utils/strategyTuple.ts
@@ -9,7 +9,7 @@ export function reduceStrategy(data: Allocation[]) {
           return [curr.val, ...acc.slice(0, 2)];
 
         case "euler":
-          return [acc[0], curr.val, ...acc.slice(1, 2)];
+          return [acc[0], curr.val, acc[1]];
 
         default:
           return [acc[0], acc[1], acc[2] + curr.val];

--- a/frontend/src/lib/utils/strategyTuple.ts
+++ b/frontend/src/lib/utils/strategyTuple.ts
@@ -1,7 +1,7 @@
 type Allocation = { name: string; val: number };
 type Strategy = number[];
 
-export function strategyTuple(data: Allocation[]) {
+export function reduceStrategy(data: Allocation[]) {
   return data.reduce(
     (acc: Strategy, curr: Allocation) => {
       switch (curr.name) {

--- a/frontend/src/routes/app/+layout.svelte
+++ b/frontend/src/routes/app/+layout.svelte
@@ -17,7 +17,7 @@
   <AppHeader />
   <div class="text-black flex flex-row h-full">
     <AppSidebar />
-    <main class="px-10 py-5 w-full">
+    <main class="px-14 py-5 w-full">
       <slot />
     </main>
   </div>

--- a/frontend/src/routes/app/proposals/+page.svelte
+++ b/frontend/src/routes/app/proposals/+page.svelte
@@ -3,10 +3,11 @@
   import Card from "$lib/components/Card.svelte";
   import Hand from "$lib/components/icons/Hand.svelte";
   import proposals from "$lib/stores/proposals";
+  import strats from "$lib/stores/strats";
+  import truncateAddress from "$lib/utils/truncateAddress";
 
   function vote(ev: MouseEvent, propId: string) {
     ev.preventDefault();
-
     proposals.vote(propId);
   }
 </script>
@@ -27,18 +28,26 @@
             <h3>Proposal #{proposalId}</h3>
             <p class="mb-3">
               Strategy #{strategyId}
-              <span>by author</span>
+              <span
+                >by {truncateAddress(
+                  strats.getStrategyAuthor(strategyId)
+                )}</span
+              >
             </p>
 
-            <div class="w-32 {finished ? 'bg-orange' : 'bg-lightGreen'}">
-              <h4 class="text-center">{finished ? "closed" : "active"}</h4>
+            <div
+              class="w-32 {Number(finished) ? 'bg-orange' : 'bg-lightGreen'}"
+            >
+              <h4 class="text-center"
+                >{Number(finished) ? "closed" : "active"}</h4
+              >
             </div>
           </div>
 
           <div class="flex flex-col items-center justify-center">
             <Button
               class="py-2 w-32 flex justify-start gap-4 mb-3"
-              disabled={!!finished}
+              disabled={!!Number(finished)}
               on:click={(ev) => vote(ev, proposalId)}
             >
               <Hand

--- a/frontend/src/routes/app/proposals/+page.svelte
+++ b/frontend/src/routes/app/proposals/+page.svelte
@@ -4,7 +4,7 @@
   import Hand from "$lib/components/icons/Hand.svelte";
   import proposals from "$lib/stores/proposals";
 
-  function vote(ev: MouseEvent, propId: number) {
+  function vote(ev: MouseEvent, propId: string) {
     ev.preventDefault();
 
     proposals.vote(propId);
@@ -16,17 +16,17 @@
 </div>
 
 <div class="flex flex-col gap-5 mt-6">
-  {#each $proposals as { strategy_id, finished, vote_list, proposal_id } (proposal_id)}
+  {#each $proposals as { strategyId, finished, voteList, proposalId } (proposalId)}
     <Card color="white">
       <a
-        href="/app/proposals/{proposal_id}"
+        href="/app/proposals/{proposalId}"
         class="w-full"
       >
         <div class="w-full flex justify-between">
           <div>
-            <h3>Proposal #{proposal_id}</h3>
+            <h3>Proposal #{proposalId}</h3>
             <p class="mb-3">
-              Strategy #{strategy_id}
+              Strategy #{strategyId}
               <span>by author</span>
             </p>
 
@@ -39,7 +39,7 @@
             <Button
               class="py-2 w-32 flex justify-start gap-4 mb-3"
               disabled={!!finished}
-              on:click={(ev) => vote(ev, proposal_id)}
+              on:click={(ev) => vote(ev, proposalId)}
             >
               <Hand
                 class="w-5 h-8"
@@ -48,7 +48,7 @@
               <h4 class="uppercase">Vote</h4>
             </Button>
             <span>
-              {vote_list.reduce((acc, curr) => acc + curr, 0)} / 8
+              {voteList.reduce((acc, curr) => acc + Number(curr), 0)} / 8
             </span>
           </div>
         </div>

--- a/frontend/src/routes/app/proposals/+page.svelte
+++ b/frontend/src/routes/app/proposals/+page.svelte
@@ -28,19 +28,17 @@
             <h3>Proposal #{proposalId}</h3>
             <p class="mb-3">
               Strategy #{strategyId}
-              <span
-                >by {truncateAddress(
-                  strats.getStrategyAuthor(strategyId)
-                )}</span
-              >
+              <span>
+                by {truncateAddress(strats.getStrategyAuthor(strategyId))}
+              </span>
             </p>
 
             <div
               class="w-32 {Number(finished) ? 'bg-orange' : 'bg-lightGreen'}"
             >
-              <h4 class="text-center"
-                >{Number(finished) ? "closed" : "active"}</h4
-              >
+              <h4 class="text-center">
+                {Number(finished) ? "closed" : "active"}
+              </h4>
             </div>
           </div>
 

--- a/frontend/src/routes/app/proposals/[id]/+page.svelte
+++ b/frontend/src/routes/app/proposals/[id]/+page.svelte
@@ -7,6 +7,8 @@
   import proposals from "$lib/stores/proposals";
   import type { Strategy } from "$lib/stores/strats";
   import StratPieChart from "$lib/components/StratPieChart.svelte";
+  import strats from "$lib/stores/strats";
+  import truncateAddress from "$lib/utils/truncateAddress";
 
   export let data: any;
 
@@ -41,6 +43,7 @@
     </div>
     <div class="mb-10">
       <h3>Strategy #{strategy.id}</h3>
+      <span>by {truncateAddress(strats.getStrategyAuthor(strategy.id))}</span>
     </div>
     <StratPieChart {assets} />
   </article>

--- a/frontend/src/routes/app/proposals/[id]/+page.svelte
+++ b/frontend/src/routes/app/proposals/[id]/+page.svelte
@@ -15,10 +15,12 @@
   const { proposal, strategy }: { proposal: Proposal; strategy: Strategy } =
     data;
 
-  const assets = strategy.data.map((amount: number, idx: number) => ({
-    name: ["rocket pool", "euler", "uniswap"][idx],
-    val: amount,
-  }));
+  const assets =
+    strategy.assets ||
+    strategy.data.map((amount: number, idx: number) => ({
+      name: ["rocket pool", "euler", "uniswap"][idx],
+      val: amount,
+    }));
 </script>
 
 <Button

--- a/frontend/src/routes/app/proposals/[id]/+page.svelte
+++ b/frontend/src/routes/app/proposals/[id]/+page.svelte
@@ -32,7 +32,7 @@
 </Button>
 <div class="flex justify-between gap-8">
   <article>
-    <h2 class="mb-2">Proposal #{proposal.proposal_id}</h2>
+    <h2 class="mb-2">Proposal #{proposal.proposalId}</h2>
     <div class="flex justify-between mb-14">
       <p>by author</p>
       <div class="w-32 bg-lightGreen">
@@ -49,7 +49,7 @@
       <Button
         class="py-2 w-32 flex justify-start gap-4 mb-3"
         color="white"
-        on:click={() => proposals.vote(proposal.proposal_id)}
+        on:click={() => proposals.vote(proposal.proposalId)}
       >
         <Hand
           class="w-5 h-8"
@@ -58,7 +58,7 @@
         <h4 class="uppercase">Vote</h4>
       </Button>
       <span>
-        {proposal.vote_list.reduce((acc, curr) => acc + curr, 0)} / 8
+        {proposal.voteList.reduce((acc, curr) => acc + Number(curr), 0)} / 8
       </span>
     </div>
   </Card>

--- a/frontend/src/routes/app/proposals/[id]/+page.svelte
+++ b/frontend/src/routes/app/proposals/[id]/+page.svelte
@@ -32,20 +32,19 @@
   />
   Back
 </Button>
-<div class="flex justify-between gap-8">
-  <article>
+<div class="flex justify-between gap-4">
+  <article class="w-4/5">
     <h2 class="mb-2">Proposal #{proposal.proposalId}</h2>
-    <div class="flex justify-between mb-14">
-      <p>by author</p>
-      <div class="w-32 bg-lightGreen">
-        <h4 class="text-center">active</h4>
+    <div class="w-32 bg-lightGreen">
+      <h4 class="text-center">active</h4>
+    </div>
+    <div class="mx-auto w-2/5 text-center">
+      <div class="mb-4">
+        <h3>Strategy #{strategy.id}</h3>
+        <p>by {truncateAddress(strats.getStrategyAuthor(strategy.id))}</p>
       </div>
+      <StratPieChart {assets} />
     </div>
-    <div class="mb-10">
-      <h3>Strategy #{strategy.id}</h3>
-      <span>by {truncateAddress(strats.getStrategyAuthor(strategy.id))}</span>
-    </div>
-    <StratPieChart {assets} />
   </article>
   <Card color="lightGreen">
     <div class="flex flex-col gap-4 items-center">

--- a/frontend/src/routes/app/proposals/[id]/+page.ts
+++ b/frontend/src/routes/app/proposals/[id]/+page.ts
@@ -4,12 +4,10 @@ import proposals, { type Proposal } from "$lib/stores/proposals";
 import strats from "$lib/stores/strats";
 
 export function load({ params: { id } }: { params: { id: string } }) {
-  const data = get(proposals).find(
-    (item: Proposal) => item.proposal_id === Number(id)
-  );
+  const data = get(proposals).find((item: Proposal) => item.proposalId === id);
 
   const strategy = get(strats).find(
-    (strat) => Number(strat.id) === data?.strategy_id
+    (strat) => Number(strat.id) === data?.strategyId
   );
 
   if (data) {

--- a/frontend/src/routes/app/proposals/[id]/+page.ts
+++ b/frontend/src/routes/app/proposals/[id]/+page.ts
@@ -6,9 +6,7 @@ import strats from "$lib/stores/strats";
 export function load({ params: { id } }: { params: { id: string } }) {
   const data = get(proposals).find((item: Proposal) => item.proposalId === id);
 
-  const strategy = get(strats).find(
-    (strat) => Number(strat.id) === data?.strategyId
-  );
+  const strategy = get(strats).find((strat) => strat.id === data?.strategyId);
 
   if (data) {
     return {

--- a/frontend/src/routes/app/strategies/+layout.svelte
+++ b/frontend/src/routes/app/strategies/+layout.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-  import MetaMaskConnect from "$lib/components/MetaMaskConnect.svelte";
-</script>
-
-<div class="absolute right-8">
-  <MetaMaskConnect />
-</div>
-
-<slot />

--- a/frontend/src/routes/app/strategies/+page.svelte
+++ b/frontend/src/routes/app/strategies/+page.svelte
@@ -5,10 +5,14 @@
   import Card from "$lib/components/Card.svelte";
   import metamask from "$lib/stores/metamask";
   import truncateAddress from "$lib/utils/truncateAddress";
+  import MetaMaskConnect from "$lib/components/MetaMaskConnect.svelte";
 </script>
 
 <div>
-  <h2 class="mb-10">Strategies</h2>
+  <div class="flex justify-between items-baseline">
+    <h2 class="mb-10">Strategies</h2>
+    <MetaMaskConnect />
+  </div>
 
   {#if $metamask}
     <Button

--- a/frontend/src/routes/app/strategies/[id]/+page.svelte
+++ b/frontend/src/routes/app/strategies/[id]/+page.svelte
@@ -2,6 +2,7 @@
   import Button from "$lib/components/Button.svelte";
   import StratPieChart from "$lib/components/StratPieChart.svelte";
   import { contracts } from "$lib/svark";
+  import proposals from "$lib/stores/proposals";
   import truncateAddress from "$lib/utils/truncateAddress";
 
   export let data: any;
@@ -12,12 +13,6 @@
     name: ["rocket pool", "euler", "uniswap"][idx],
     val: amount,
   }));
-
-  async function handleClick() {
-    const proposalData = await $starknetContract.create_proposal(data.id);
-
-    console.log(proposalData);
-  }
 </script>
 
 <h3>Strategy #{data.id}</h3>
@@ -30,7 +25,7 @@
   color="lightGreen"
   type="button"
   disabled={!$starknetContract}
-  on:click={handleClick}
+  on:click={() => proposals.createProposal(data.id)}
 >
   {$starknetContract
     ? "Propose this strategy"

--- a/frontend/src/routes/app/strategies/[id]/+page.svelte
+++ b/frontend/src/routes/app/strategies/[id]/+page.svelte
@@ -10,10 +10,12 @@
 
   $: starknetContract = $contracts.starknet;
 
-  const assets = data.data.map((amount: number, idx: number) => ({
-    name: ["rocket pool", "euler", "uniswap"][idx],
-    val: amount,
-  }));
+  const assets =
+    data.assets ||
+    data.data.map((amount: number, idx: number) => ({
+      name: ["rocket pool", "euler", "uniswap"][idx],
+      val: amount,
+    }));
 </script>
 
 <Button

--- a/frontend/src/routes/app/strategies/[id]/+page.svelte
+++ b/frontend/src/routes/app/strategies/[id]/+page.svelte
@@ -4,6 +4,7 @@
   import { contracts } from "$lib/svark";
   import proposals from "$lib/stores/proposals";
   import truncateAddress from "$lib/utils/truncateAddress";
+  import ReturnArrow from "$lib/components/icons/ReturnArrow.svelte";
 
   export let data: any;
 
@@ -15,9 +16,20 @@
   }));
 </script>
 
+<Button
+  class="w-fit py-1 px-2 gap-3 mb-6"
+  href="/app/strategies"
+  color="lightGreen"
+>
+  <ReturnArrow
+    class="fill-black w-7 h-5"
+    slot="leftIcon"
+  />
+  Back
+</Button>
 <h3>Strategy #{data.id}</h3>
 <p>by {truncateAddress(data.submittedBy)}</p>
-<div class="w-2/4 mx-auto mb-10">
+<div class="w-2/6 mx-auto mb-10">
   <StratPieChart {assets} />
 </div>
 <Button


### PR DESCRIPTION
Why:
- Proposal and strategies store were using old data and not updating when new proposals/strategies get created

How:
- Update initial data
- Store new strategies and proposals locally when new ones are created
- Minor ui changes, like adding back button to `proposals/[id]`, adjusting graph size and position